### PR TITLE
feat(versioning): version 5.1.2-1.0

### DIFF
--- a/phoenix-assembly/pom.xml
+++ b/phoenix-assembly/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>5.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>5.1.2-1.0</version>
   </parent>
   <artifactId>phoenix-assembly</artifactId>
   <name>Phoenix Assembly</name>

--- a/phoenix-client-parent/phoenix-client-embedded/pom.xml
+++ b/phoenix-client-parent/phoenix-client-embedded/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix-client-parent</artifactId>
-    <version>5.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>5.1.2-1.0</version>
   </parent>
 
   <artifactId>phoenix-client-embedded-${hbase.suffix}</artifactId>

--- a/phoenix-client-parent/phoenix-client/pom.xml
+++ b/phoenix-client-parent/phoenix-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix-client-parent</artifactId>
-    <version>5.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>5.1.2-1.0</version>
   </parent>
 
   <artifactId>phoenix-client-${hbase.suffix}</artifactId>

--- a/phoenix-client-parent/pom.xml
+++ b/phoenix-client-parent/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>5.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>5.1.2-1.0</version>
   </parent>
   <artifactId>phoenix-client-parent</artifactId>
   <name>Phoenix Client Parent</name>

--- a/phoenix-core/pom.xml
+++ b/phoenix-core/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>5.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>5.1.2-1.0</version>
   </parent>
   <artifactId>phoenix-core</artifactId>
   <name>Phoenix Core</name>

--- a/phoenix-hbase-compat-2.1.6/pom.xml
+++ b/phoenix-hbase-compat-2.1.6/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>5.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>5.1.2-1.0</version>
   </parent>
 
   <artifactId>phoenix-hbase-compat-2.1.6</artifactId>

--- a/phoenix-hbase-compat-2.2.5/pom.xml
+++ b/phoenix-hbase-compat-2.2.5/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>5.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>5.1.2-1.0</version>
   </parent>
 
   <artifactId>phoenix-hbase-compat-2.2.5</artifactId>

--- a/phoenix-hbase-compat-2.3.0/pom.xml
+++ b/phoenix-hbase-compat-2.3.0/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>5.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>5.1.2-1.0</version>
   </parent>
 
   <artifactId>phoenix-hbase-compat-2.3.0</artifactId>

--- a/phoenix-hbase-compat-2.4.0/pom.xml
+++ b/phoenix-hbase-compat-2.4.0/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>5.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>5.1.2-1.0</version>
   </parent>
 
   <artifactId>phoenix-hbase-compat-2.4.0</artifactId>

--- a/phoenix-hbase-compat-2.4.1/pom.xml
+++ b/phoenix-hbase-compat-2.4.1/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>5.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>5.1.2-1.0</version>
   </parent>
 
   <artifactId>phoenix-hbase-compat-2.4.1</artifactId>

--- a/phoenix-pherf/pom.xml
+++ b/phoenix-pherf/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>5.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>5.1.2-1.0</version>
   </parent>
 
   <artifactId>phoenix-pherf</artifactId>

--- a/phoenix-server/pom.xml
+++ b/phoenix-server/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>5.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>5.1.2-1.0</version>
   </parent>
   <artifactId>phoenix-server-${hbase.suffix}</artifactId>
   <name>Phoenix Server JAR</name>

--- a/phoenix-tracing-webapp/pom.xml
+++ b/phoenix-tracing-webapp/pom.xml
@@ -22,7 +22,7 @@
     <parent>
       <groupId>org.apache.phoenix</groupId>
       <artifactId>phoenix</artifactId>
-      <version>5.1.3-TDP-0.1.0-SNAPSHOT</version>
+      <version>5.1.2-1.0</version>
     </parent>
 
     <artifactId>phoenix-tracing-webapp</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.phoenix</groupId>
   <artifactId>phoenix</artifactId>
-  <version>5.1.3-TDP-0.1.0-SNAPSHOT</version>
+  <version>5.1.2-1.0</version>
   <packaging>pom</packaging>
   <name>Apache Phoenix</name>
   <description>A SQL layer over HBase</description>


### PR DESCRIPTION
This PR applies validated TDP versioning on branch 5.1.2

Changes are:

modified version from 5.1.3-TDP-0.1.0-SNAPSHOT to 5.1.2-1.0

Why decreasing from 5.1.3.. to 5.1.2 ?

5.1.3-TDP-0.1.0-SNAPSHOT was based on a snapshot version, which is technically 5.1.2 with a cumulative patch.
