### PR TITLE
Phoenix 5.1.3-2.0

### DIFF
--- a/phoenix-assembly/pom.xml
+++ b/phoenix-assembly/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>5.1.3-1.0</version>
+    <version>5.1.3-2.0-SNAPSHOT</version>
   </parent>
   <artifactId>phoenix-assembly</artifactId>
   <name>Phoenix Assembly</name>

--- a/phoenix-client-parent/phoenix-client-embedded/pom.xml
+++ b/phoenix-client-parent/phoenix-client-embedded/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix-client-parent</artifactId>
-    <version>5.1.3-1.0</version>
+    <version>5.1.3-2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>phoenix-client-embedded-${hbase.suffix}</artifactId>

--- a/phoenix-client-parent/phoenix-client/pom.xml
+++ b/phoenix-client-parent/phoenix-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix-client-parent</artifactId>
-    <version>5.1.3-1.0</version>
+    <version>5.1.3-2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>phoenix-client-${hbase.suffix}</artifactId>

--- a/phoenix-client-parent/pom.xml
+++ b/phoenix-client-parent/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>5.1.3-1.0</version>
+    <version>5.1.3-2.0-SNAPSHOT</version>
   </parent>
   <artifactId>phoenix-client-parent</artifactId>
   <name>Phoenix Client Parent</name>

--- a/phoenix-core/pom.xml
+++ b/phoenix-core/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>5.1.3-1.0</version>
+    <version>5.1.3-2.0-SNAPSHOT</version>
   </parent>
   <artifactId>phoenix-core</artifactId>
   <name>Phoenix Core</name>

--- a/phoenix-hbase-compat-2.1.6/pom.xml
+++ b/phoenix-hbase-compat-2.1.6/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>5.1.3-1.0</version>
+    <version>5.1.3-2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>phoenix-hbase-compat-2.1.6</artifactId>

--- a/phoenix-hbase-compat-2.3.0/pom.xml
+++ b/phoenix-hbase-compat-2.3.0/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>5.1.3-1.0</version>
+    <version>5.1.3-2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>phoenix-hbase-compat-2.3.0</artifactId>

--- a/phoenix-hbase-compat-2.4.0/pom.xml
+++ b/phoenix-hbase-compat-2.4.0/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>5.1.3-1.0</version>
+    <version>5.1.3-2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>phoenix-hbase-compat-2.4.0</artifactId>

--- a/phoenix-hbase-compat-2.4.1/pom.xml
+++ b/phoenix-hbase-compat-2.4.1/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>5.1.3-1.0</version>
+    <version>5.1.3-2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>phoenix-hbase-compat-2.4.1</artifactId>

--- a/phoenix-hbase-compat-2.5.0/pom.xml
+++ b/phoenix-hbase-compat-2.5.0/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>5.1.3-1.0</version>
+    <version>5.1.3-2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>phoenix-hbase-compat-2.5.0</artifactId>

--- a/phoenix-pherf/pom.xml
+++ b/phoenix-pherf/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>5.1.3-1.0</version>
+    <version>5.1.3-2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>phoenix-pherf</artifactId>

--- a/phoenix-server/pom.xml
+++ b/phoenix-server/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>5.1.3-1.0</version>
+    <version>5.1.3-2.0-SNAPSHOT</version>
   </parent>
   <artifactId>phoenix-server-${hbase.suffix}</artifactId>
   <name>Phoenix Server JAR</name>

--- a/phoenix-tracing-webapp/pom.xml
+++ b/phoenix-tracing-webapp/pom.xml
@@ -22,7 +22,7 @@
     <parent>
       <groupId>org.apache.phoenix</groupId>
       <artifactId>phoenix</artifactId>
-      <version>5.1.3-1.0</version>
+      <version>5.1.3-2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>phoenix-tracing-webapp</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1679,7 +1679,7 @@
         <hbase.profile>2.1</hbase.profile>
         <hbase.compat.version>2.1.6</hbase.compat.version>
         <hbase.version>${hbase-2.1.runtime.version}</hbase.version>
-        <hadoop.version>3.1.1-0.0</hadoop.version>
+        <hadoop.version>3.1.4-1.0-SNAPSHOT</hadoop.version>
         <tephra.hbase.compat.version>2.1</tephra.hbase.compat.version>
       </properties>
     </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <!-- This is used by the release script only -->
     <hbase.profile.list>2.1 2.2 2.3 2.4.0 2.4 2.5</hbase.profile.list>
     <!-- The default hbase versions to build with (override with hbase.version) -->
-    <hbase-2.1.runtime.version>2.1.10-1.0</hbase-2.1.runtime.version>
+    <hbase-2.1.runtime.version>2.1.10-2.0-SNAPSHOT</hbase-2.1.runtime.version>
     <hbase-2.2.runtime.version>2.2.7</hbase-2.2.runtime.version>
     <hbase-2.3.runtime.version>2.3.7</hbase-2.3.runtime.version>
     <hbase-2.4.0.runtime.version>2.4.0</hbase-2.4.0.runtime.version>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.phoenix</groupId>
   <artifactId>phoenix</artifactId>
-  <version>5.1.3-1.0</version>
+  <version>5.1.3-2.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Apache Phoenix</name>
   <description>A SQL layer over HBase</description>

--- a/tdp/README.md
+++ b/tdp/README.md
@@ -1,6 +1,6 @@
 # TDP Phoenix Notes
 
-The version 5.1.3-1.0 of Apache Phoenix is based on the branch `5.1` tag of the Apache [repository](https://github.com/apache/phoenix/tree/5.1).
+The version 5.1.3-2.0-SNAPSHOT of Apache Phoenix is based on the branch `5.1` tag of the Apache [repository](https://github.com/apache/phoenix/tree/5.1).
 
 ## Making a release
 
@@ -8,7 +8,7 @@ The version 5.1.3-1.0 of Apache Phoenix is based on the branch `5.1` tag of the 
 mvn clean install -DskipTests -Dhbase.profile=2.1
 ```
 
-This command generates `phoenix-hbase-2.1-5.1.3-1.0-bin.tar.gz` file in the `phoenix-assembly/target` directory.
+This command generates `phoenix-hbase-2.1-5.1.3-2.0-SNAPSHOT-bin.tar.gz` file in the `phoenix-assembly/target` directory.
 
 ## To run tests
 
@@ -17,7 +17,7 @@ This command generates `phoenix-hbase-2.1-5.1.3-1.0-bin.tar.gz` file in the `pho
 mvn test -Dhbase.profile=2.1 -DPhoenixPatchProcess -Dskip.code-coverage
 ```
 
-- -Dhbase.profile=2.1, builds phoenix with hbase 2.1.10-1.0 and hadoop 3.1.1-0.0
+- -Dhbase.profile=2.1, builds phoenix with hbase 2.1.10-2.0-SNAPSHOT and hadoop 3.1.4-1.0-SNAPSHOT
 - -DPhoenixPatchProcess, disables the build of the shaded artifacts (not necessary for tests)
 - -Dskip.code-coverage, self explanatory
 
@@ -27,6 +27,6 @@ mvn test -Dhbase.profile=2.1 -DPhoenixPatchProcess -Dskip.code-coverage
 mvn verify -Dhbase.profile=2.1 -DPhoenixPatchProcess -Dskip.code-coverage
 ```
 
-- -Dhbase.profile=2.1, builds phoenix with hbase 2.1.10-1.0 and hadoop 3.1.1-0.0
+- -Dhbase.profile=2.1, builds phoenix with hbase 2.1.10-2.0-SNAPSHOT and hadoop 3.1.4-1.0-SNAPSHOT
 - -DPhoenixPatchProcess, disables the build of the shaded artifacts (not necessary for tests)
 - -Dskip.code-coverage, self explanatory


### PR DESCRIPTION
Relates to https://github.com/TOSIT-IO/TDP/pull/90

Included in the PR:

Bump 2 TDP dependencies (hadoop, hbase) to their TDP 1.1 versions.